### PR TITLE
fixed firstname display bug

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -191,6 +191,7 @@ router.post("/profile",
           firstName: `${user.firstName}`
         }
       });
+      var welcomeTitleName = req.body.firstName;
     }
     if(req.body.lastName){
       await db.User.update({ lastName: `${req.body.lastName}` }, {
@@ -198,6 +199,9 @@ router.post("/profile",
           lastName: `${user.lastName}`
         }
       });
+      if(!req.body.firstName){
+        var welcomeTitleName = user.firstName;
+      }
     }
     if(req.body.emailAddress){
       await db.User.update({ emailAddress: `${req.body.emailAddress}` }, {
@@ -205,6 +209,9 @@ router.post("/profile",
           emailAddress: `${user.emailAddress}`
         }
       });
+      if(!req.body.firstName){
+        var welcomeTitleName = user.firstName;
+      }
     }
 
     const topics = await db.Topic.findAll();
@@ -214,7 +221,7 @@ router.post("/profile",
     if (req.session.auth) {
       const userId = req.session.auth.userId;
       const user = await db.User.findByPk(userId);
-      res.render("index", { posts, topics, title: `Welcome to GitGud, ${req.body.firstName}!` })
+      res.render("index", { posts, topics, title: `Welcome to GitGud, ${welcomeTitleName}!` })
     }
   })
 );


### PR DESCRIPTION
there was a bug where when a user edited their last name or email or both but did not edit their first name, then the first name would not show up on the redirect to the home page the first time, so I had to change how the user's first name was being passed to the pug welcome title, which will now display the new first name if it was changed and the old first name if the last name or email or both were edited and not the first name. 